### PR TITLE
shared text feature

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,6 +26,13 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <data android:mimeType="*/*" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+
+
         </activity>
         <receiver
             android:name=".SmsReceivedReceiver"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,8 +31,6 @@
                 <data android:mimeType="text/plain" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
-
-
         </activity>
         <receiver
             android:name=".SmsReceivedReceiver"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
-                <data android:mimeType="*/*" />
+                <data android:mimeType="text/plain" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,7 +21,13 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@android:style/Theme.Material.Wallpaper.NoTitleBar">
-        <activity android:name=".MainActivity" android:screenOrientation="portrait" android:launchMode="singleInstance">
+        <activity
+            android:name=".MainActivity"
+            android:allowTaskReparenting="true"
+            android:autoRemoveFromRecents="true"
+            android:launchMode="singleInstance"
+            android:screenOrientation="portrait"
+            android:taskAffinity="">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/java/com/candroid/textme/MainActivity.java
+++ b/app/src/main/java/com/candroid/textme/MainActivity.java
@@ -154,8 +154,7 @@ public class MainActivity extends ListActivity {
     @Override
     protected void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
-        Toast.makeText(this, intent.getAction(), Toast.LENGTH_SHORT).show();
-        if (intent.getAction().equals("android.intent.action.SEND")) {
+        if (intent != null && intent.getAction() != null && !intent.getAction().equals("android.intent.action.MAIN")) {
             Toast.makeText(this, "text to share: ".concat(intent.getStringExtra(Intent.EXTRA_TEXT)), Toast.LENGTH_SHORT).show();
         }
     }

--- a/app/src/main/java/com/candroid/textme/MainActivity.java
+++ b/app/src/main/java/com/candroid/textme/MainActivity.java
@@ -17,6 +17,7 @@ import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.net.Uri;
+import android.os.Bundle;
 import android.provider.ContactsContract;
 import android.provider.Telephony;
 import android.telephony.SmsManager;
@@ -52,15 +53,7 @@ public class MainActivity extends ListActivity {
     private Map<String, String> mContacts;
     private BroadcastReceiver mSentReceiver, mDeliveredReceiver, mReceivedReceiver;
 
-    @Override
-    protected void onNewIntent(Intent intent) {
-        super.onNewIntent(intent);
-        Toast.makeText(this, intent.getAction(), Toast.LENGTH_SHORT).show();
-        /*another app shared text to our app*/
-        if (!intent.getAction().equals("android.intent.action.MAIN")) {
-            Toast.makeText(this, "text to share: ".concat(intent.getStringExtra(Intent.EXTRA_TEXT)), Toast.LENGTH_SHORT).show();
-        }
-    }
+
 
     /*remove country code from telephone address - example:+1*/
     private static String removeCountryCode(String address) {
@@ -108,6 +101,13 @@ public class MainActivity extends ListActivity {
         }
     }
 
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        /*check if receiving implicit intent from another app because we were not in background*/
+        onNewIntent(getIntent());
+    }
+
     /*initialize everything that is deinitialized in onstop*/
     @Override
     protected void onStart() {
@@ -149,6 +149,17 @@ public class MainActivity extends ListActivity {
     protected void onDestroy() {
         super.onDestroy();
         finishAndRemoveTask();
+    }
+
+    /*received implicit intent from another app while in background*/
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        Toast.makeText(this, intent.getAction(), Toast.LENGTH_SHORT).show();
+        /*another app shared text to our app*/
+        if (intent.getAction().equals("android.intent.action.SEND")) {
+            Toast.makeText(this, "text to share: ".concat(intent.getStringExtra(Intent.EXTRA_TEXT)), Toast.LENGTH_SHORT).show();
+        }
     }
 
     @Override

--- a/app/src/main/java/com/candroid/textme/MainActivity.java
+++ b/app/src/main/java/com/candroid/textme/MainActivity.java
@@ -52,6 +52,16 @@ public class MainActivity extends ListActivity {
     private Map<String, String> mContacts;
     private BroadcastReceiver mSentReceiver, mDeliveredReceiver, mReceivedReceiver;
 
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        Toast.makeText(this, intent.getAction(), Toast.LENGTH_SHORT).show();
+        /*another app shared text to our app*/
+        if (!intent.getAction().equals("android.intent.action.MAIN")) {
+            Toast.makeText(this, "text to share: ".concat(intent.getStringExtra(Intent.EXTRA_TEXT)), Toast.LENGTH_SHORT).show();
+        }
+    }
+
     /*remove country code from telephone address - example:+1*/
     private static String removeCountryCode(String address) {
         if (address.length() > 11 && address.contains("+") && address.indexOf("+") == 0) {

--- a/app/src/main/java/com/candroid/textme/MainActivity.java
+++ b/app/src/main/java/com/candroid/textme/MainActivity.java
@@ -278,15 +278,13 @@ public class MainActivity extends ListActivity {
                         Toast.makeText(getBaseContext(), "sms sent", Toast.LENGTH_SHORT).show();
                         if (sTextToShare != null) {
                             sTextToShare = null;
-                            MainActivity.this.setResult(Activity.RESULT_OK);
-                            MainActivity.this.finish();
+                            MainActivity.this.finishAndRemoveTask();
                         }
                         break;
                     default:
                         if (sTextToShare != null) {
                             sTextToShare = null;
-                            MainActivity.this.setResult(Activity.RESULT_CANCELED);
-                            MainActivity.this.finish();
+                            MainActivity.this.finishAndRemoveTask();
                         }
                         Toast.makeText(getBaseContext(), "sms failed", Toast.LENGTH_SHORT).show();
                         break;

--- a/app/src/main/java/com/candroid/textme/MainActivity.java
+++ b/app/src/main/java/com/candroid/textme/MainActivity.java
@@ -104,7 +104,6 @@ public class MainActivity extends ListActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        /*check if receiving implicit intent from another app because we were not in background*/
         onNewIntent(getIntent());
     }
 
@@ -156,7 +155,6 @@ public class MainActivity extends ListActivity {
     protected void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
         Toast.makeText(this, intent.getAction(), Toast.LENGTH_SHORT).show();
-        /*another app shared text to our app*/
         if (intent.getAction().equals("android.intent.action.SEND")) {
             Toast.makeText(this, "text to share: ".concat(intent.getStringExtra(Intent.EXTRA_TEXT)), Toast.LENGTH_SHORT).show();
         }

--- a/app/src/main/java/com/candroid/textme/MainActivity.java
+++ b/app/src/main/java/com/candroid/textme/MainActivity.java
@@ -53,8 +53,6 @@ public class MainActivity extends ListActivity {
     private Map<String, String> mContacts;
     private BroadcastReceiver mSentReceiver, mDeliveredReceiver, mReceivedReceiver;
 
-
-
     /*remove country code from telephone address - example:+1*/
     private static String removeCountryCode(String address) {
         if (address.length() > 11 && address.contains("+") && address.indexOf("+") == 0) {
@@ -101,53 +99,11 @@ public class MainActivity extends ListActivity {
         }
     }
 
+    /*initialize everything that is uninitialized in onDestroy*/
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         onNewIntent(getIntent());
-    }
-
-    /*initialize everything that is deinitialized in onstop*/
-    @Override
-    protected void onStart() {
-        super.onStart();
-        initializeUi();
-    }
-
-    /*initialize everything that is deinitialized in onPause*/
-    @Override
-    protected void onResume() {
-        super.onResume();
-        initializeBroadcastReceivers();
-    }
-
-    /*deinitialize everything that is initialized in onResume*/
-    @Override
-    protected void onPause() {
-        super.onPause();
-        unregisterReceiver(mReceivedReceiver);
-        unregisterReceiver(mSentReceiver);
-        unregisterReceiver(mDeliveredReceiver);
-        mReceivedReceiver = null;
-        mSentReceiver = null;
-        mDeliveredReceiver = null;
-    }
-
-    /*deinitialize everything that is initialized in onStart*/
-    @Override
-    protected void onStop() {
-        super.onStop();
-        getListView().removeAllViewsInLayout();
-        getListView().setEmptyView(null);
-        setListAdapter(null);
-        mContacts = null;
-    }
-
-    /*deinitialize everything that is initialized in onCreate*/
-    @Override
-    protected void onDestroy() {
-        super.onDestroy();
-        finishAndRemoveTask();
     }
 
     /*received implicit intent from another app while in background*/
@@ -157,6 +113,20 @@ public class MainActivity extends ListActivity {
         if (intent != null && intent.getAction() != null && !intent.getAction().equals("android.intent.action.MAIN")) {
             Toast.makeText(this, "text to share: ".concat(intent.getStringExtra(Intent.EXTRA_TEXT)), Toast.LENGTH_SHORT).show();
         }
+    }
+
+    /*initialize everything that is uninitialized in onstop*/
+    @Override
+    protected void onStart() {
+        super.onStart();
+        initializeUi();
+    }
+
+    /*initialize everything that is uninitialized in onPause*/
+    @Override
+    protected void onResume() {
+        super.onResume();
+        initializeBroadcastReceivers();
     }
 
     @Override
@@ -369,5 +339,34 @@ public class MainActivity extends ListActivity {
         PendingIntent sentIntent = PendingIntent.getBroadcast(this, 0, new Intent(SENT_SMS_FLAG), 0);
         PendingIntent deliveredIntent = PendingIntent.getBroadcast(this, 0, new Intent(DELIVER_SMS_FLAG), 0);
         SmsManager.getDefault().sendTextMessage(mContacts.getOrDefault(received.substring(0, received.indexOf(NEW_LINE)), "+1234567892"), null, response.trim(), sentIntent, deliveredIntent);
+    }
+
+    /*uninitialize everything that is initialized in onResume*/
+    @Override
+    protected void onPause() {
+        super.onPause();
+        unregisterReceiver(mReceivedReceiver);
+        unregisterReceiver(mSentReceiver);
+        unregisterReceiver(mDeliveredReceiver);
+        mReceivedReceiver = null;
+        mSentReceiver = null;
+        mDeliveredReceiver = null;
+    }
+
+    /*uninitialize everything that is initialized in onStart*/
+    @Override
+    protected void onStop() {
+        super.onStop();
+        getListView().removeAllViewsInLayout();
+        getListView().setEmptyView(null);
+        setListAdapter(null);
+        mContacts = null;
+    }
+
+    /*uninitialize everything that is initialized in onCreate*/
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        finishAndRemoveTask();
     }
 }


### PR DESCRIPTION
make app an option to user when sharing any type of text data. display phone book and allow user to select then send sms and send user back to app that shared. works great with newsme. share story to textme from newsme. share story from newsme to duckduckgo browser then share from browser to textme. everything is really nice but some of the activity lifecycles are firing because i am using singleinstance and single instance activities are not able to call startActivityResult apparently. it will fire onActivityResult immediately instead as well as loop onResume and onStop.